### PR TITLE
create interactive_hist

### DIFF
--- a/examples/hist.ipynb
+++ b/examples/hist.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib ipympl\n",
+    "import ipywidgets as widgets\n",
+    "out = widgets.Output()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.widgets import Slider\n",
+    "from matplotlib.patches import Rectangle\n",
+    "from matplotlib.collections import PatchCollection\n",
+    "from matplotlib import get_backend\n",
+    "\n",
+    "def f(loc, scale):\n",
+    "    return np.random.randn(10000)*scale + loc\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "plt.subplots_adjust( bottom=0.25)\n",
+    "pc = PatchCollection([])\n",
+    "ax.add_collection(pc)\n",
+    "axcolor = 'lightgoldenrodyellow'\n",
+    "ax_sigma = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)\n",
+    "ax_mean = plt.axes([0.25, 0.15, 0.65, 0.03], facecolor=axcolor)\n",
+    "\n",
+    "loc_slider = Slider(ax_mean, 'mean', -10, 10, valinit=1.5, valstep=.1)\n",
+    "scale_slider = Slider(ax_sigma, 'sigma', 0.5, 10.0, valinit=.1)\n",
+    "\n",
+    "def update_plot(change):\n",
+    "    arr = f(loc_slider.val, scale_slider.val)\n",
+    "    heights, bins = np.histogram(arr, bins='auto', density=True)\n",
+    "    width = bins[1]-bins[0]\n",
+    "    new_patches = []\n",
+    "    for i in range(len(heights)):\n",
+    "        new_patches.append(Rectangle((bins[i],0), width=width, height=heights[i]))\n",
+    "    pc.set_paths(new_patches)\n",
+    "    fig.canvas.draw() # same effect with draw_idle\n",
+    "\n",
+    "loc_slider.on_changed(update_plot)\n",
+    "scale_slider.on_changed(update_plot)\n",
+    "\n",
+    "update_plot(None) # call once to populate the initial state\n",
+    "ax.set_title(f\"Using the {get_backend()} backend\")\n",
+    "ax.set_ylim([0,1])\n",
+    "ax.set_xlim([-12.5,12.5])\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def simple_hist(arr, bins='auto', density=None, weights=None):\n",
+    "    heights, bins = np.histogram(arr, bins=bins,  density=density,weights=weights)\n",
+    "    width = bins[1]-bins[0]\n",
+    "    new_patches = []\n",
+    "    for i in range(len(heights)):\n",
+    "        new_patches.append(Rectangle((bins[i],0), width=width, height=heights[i]))\n",
+    "    return new_patches\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import ipywidgets as widgets\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.widgets import Slider\n",
+    "from matplotlib.patches import Rectangle\n",
+    "from matplotlib.collections import PatchCollection\n",
+    "from matplotlib import get_backend\n",
+    "\n",
+    "def f(loc, scale):\n",
+    "    return np.random.randn(10000)*scale + loc\n",
+    "\n",
+    "loc_slider = widgets.FloatSlider(description='mean', min=-10, max=10, value=1.5)\n",
+    "scale_slider = widgets.FloatSlider(description='sigma', min=0.5, max=10.0, value=.1)\n",
+    "display(loc_slider)\n",
+    "display(scale_slider)\n",
+    "fig, ax = plt.subplots()\n",
+    "pc = PatchCollection([])\n",
+    "ax.add_collection(pc)\n",
+    "\n",
+    "\n",
+    "def update_plot(change):\n",
+    "    arr = f(loc_slider.value, scale_slider.value)\n",
+    "#     print(arr)\n",
+    "    new_patches = simple_hist(arr, density=True)\n",
+    "#     heights, bins = np.histogram(arr, bins='auto', density=True)\n",
+    "#     width = bins[1]-bins[0]\n",
+    "#     new_patches = []\n",
+    "#     for i in range(len(heights)):\n",
+    "#         new_patches.append(Rectangle((bins[i],0), width=width, height=heights[i]))\n",
+    "    pc.set_paths(new_patches)\n",
+    "    ax.relim()\n",
+    "    ax.autoscale_view(True)\n",
+    "    fig.canvas.draw() # same effect with draw_idle\n",
+    "\n",
+    "loc_slider.observe(update_plot, names=['value'])\n",
+    "scale_slider.observe(update_plot, names=['value'])\n",
+    "\n",
+    "update_plot(None) # call once to populate the initial state\n",
+    "ax.set_title(f\"Using the {get_backend()} backend\")\n",
+    "ax.set_ylim([0,1])\n",
+    "ax.set_xlim([-12.5,12.5])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.histogram(arr, bins='auto')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(10_100_100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install fast-histogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import fast_histogram as fh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fh.histogram1d()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/hist.ipynb
+++ b/examples/hist.ipynb
@@ -8,54 +8,47 @@
    "source": [
     "%matplotlib ipympl\n",
     "import ipywidgets as widgets\n",
-    "out = widgets.Output()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "from matplotlib.widgets import Slider\n",
-    "from matplotlib.patches import Rectangle\n",
-    "from matplotlib.collections import PatchCollection\n",
-    "from matplotlib import get_backend\n",
+    "# %load_ext autoreload\n",
+    "# %autoreload 2\n",
+    "from mpl_interactions import interactive_hist"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "limitations:  \n",
+    "    \n",
+    "    1. only one function at a time \n",
+    "    2. zorder may be funky (this is not calling ax.hist internally)\n",
+    "    3. only vertical histograms\n",
+    "    4. no stacked histograms\n",
+    "    5. currently no labels are possible\n",
+    "        - this one may actually be worth fixing\n",
+    "    6. only allows stretching the axis limits\n",
+    "    7. the axis relimming is a bit hacky, may not be exactly equivalent to what you'd get by call plt.hist\n",
+    "    \n",
+    "There are some limitations to the current approach that could be worked around. But that would require a high amount of effort and all of these limitations should be solved by https://github.com/matplotlib/matplotlib/pull/18275\n",
     "\n",
+    "\n",
+    "This accepts the following arguments that are passed through to `np.histogram`. Here they are with their default values:\n",
+    "- `density = False`\n",
+    "- `bins = 'auto'`\n",
+    "- `weight = None`\n",
+    "\n",
+    "otherwise it works like `interactive_plot` except that f must return an array of numbers to be used `np.histogram` and `x` is no longer special"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def f(loc, scale):\n",
-    "    return np.random.randn(10000)*scale + loc\n",
-    "\n",
-    "fig, ax = plt.subplots()\n",
-    "plt.subplots_adjust( bottom=0.25)\n",
-    "pc = PatchCollection([])\n",
-    "ax.add_collection(pc)\n",
-    "axcolor = 'lightgoldenrodyellow'\n",
-    "ax_sigma = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)\n",
-    "ax_mean = plt.axes([0.25, 0.15, 0.65, 0.03], facecolor=axcolor)\n",
-    "\n",
-    "loc_slider = Slider(ax_mean, 'mean', -10, 10, valinit=1.5, valstep=.1)\n",
-    "scale_slider = Slider(ax_sigma, 'sigma', 0.5, 10.0, valinit=.1)\n",
-    "\n",
-    "def update_plot(change):\n",
-    "    arr = f(loc_slider.val, scale_slider.val)\n",
-    "    heights, bins = np.histogram(arr, bins='auto', density=True)\n",
-    "    width = bins[1]-bins[0]\n",
-    "    new_patches = []\n",
-    "    for i in range(len(heights)):\n",
-    "        new_patches.append(Rectangle((bins[i],0), width=width, height=heights[i]))\n",
-    "    pc.set_paths(new_patches)\n",
-    "    fig.canvas.draw() # same effect with draw_idle\n",
-    "\n",
-    "loc_slider.on_changed(update_plot)\n",
-    "scale_slider.on_changed(update_plot)\n",
-    "\n",
-    "update_plot(None) # call once to populate the initial state\n",
-    "ax.set_title(f\"Using the {get_backend()} backend\")\n",
-    "ax.set_ylim([0,1])\n",
-    "ax.set_xlim([-12.5,12.5])\n",
-    "plt.show()\n"
+    "    return np.random.randn(10000)*scale + loc"
    ]
   },
   {
@@ -64,14 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def simple_hist(arr, bins='auto', density=None, weights=None):\n",
-    "    heights, bins = np.histogram(arr, bins=bins,  density=density,weights=weights)\n",
-    "    width = bins[1]-bins[0]\n",
-    "    new_patches = []\n",
-    "    for i in range(len(heights)):\n",
-    "        new_patches.append(Rectangle((bins[i],0), width=width, height=heights[i]))\n",
-    "    return new_patches\n",
-    "    "
+    "interactive_hist(f, loc=(0,10,100), scale=(.5,5))"
    ]
   },
   {
@@ -80,94 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "import ipywidgets as widgets\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "from matplotlib.widgets import Slider\n",
-    "from matplotlib.patches import Rectangle\n",
-    "from matplotlib.collections import PatchCollection\n",
-    "from matplotlib import get_backend\n",
-    "\n",
-    "def f(loc, scale):\n",
-    "    return np.random.randn(10000)*scale + loc\n",
-    "\n",
-    "loc_slider = widgets.FloatSlider(description='mean', min=-10, max=10, value=1.5)\n",
-    "scale_slider = widgets.FloatSlider(description='sigma', min=0.5, max=10.0, value=.1)\n",
-    "display(loc_slider)\n",
-    "display(scale_slider)\n",
-    "fig, ax = plt.subplots()\n",
-    "pc = PatchCollection([])\n",
-    "ax.add_collection(pc)\n",
-    "\n",
-    "\n",
-    "def update_plot(change):\n",
-    "    arr = f(loc_slider.value, scale_slider.value)\n",
-    "#     print(arr)\n",
-    "    new_patches = simple_hist(arr, density=True)\n",
-    "#     heights, bins = np.histogram(arr, bins='auto', density=True)\n",
-    "#     width = bins[1]-bins[0]\n",
-    "#     new_patches = []\n",
-    "#     for i in range(len(heights)):\n",
-    "#         new_patches.append(Rectangle((bins[i],0), width=width, height=heights[i]))\n",
-    "    pc.set_paths(new_patches)\n",
-    "    ax.relim()\n",
-    "    ax.autoscale_view(True)\n",
-    "    fig.canvas.draw() # same effect with draw_idle\n",
-    "\n",
-    "loc_slider.observe(update_plot, names=['value'])\n",
-    "scale_slider.observe(update_plot, names=['value'])\n",
-    "\n",
-    "update_plot(None) # call once to populate the initial state\n",
-    "ax.set_title(f\"Using the {get_backend()} backend\")\n",
-    "ax.set_ylim([0,1])\n",
-    "ax.set_xlim([-12.5,12.5])\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.histogram(arr, bins='auto')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(10_100_100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install fast-histogram"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import fast_histogram as fh"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fh.histogram1d()"
+    "interactive_hist(f, loc=(0,10,100), scale=(.5,5), bins=100, density=True)"
    ]
   },
   {


### PR DESCRIPTION
This is a not great version. Waiting on better support in matplotlib for the full version 

limitations:  
1. only one function at a time 
2. zorder may be funky (this is not calling ax.hist internally)
3. only vertical histograms
4. no stacked histograms
5. currently no labels are possible
     - this one may actually be worth fixing
6. only allows stretching the axis limits
7. the axis relimming is a bit hacky, may not be exactly equivalent to what you'd get by call plt.hist


still useful though. Useful enough that I might even merge this without creating docs for it? spooky thought but this would be to release it so kevin and I can make use of it