### PR TITLE
Issue35 documentation

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -6,9 +6,9 @@ API
 pyplot
 ------
 
-Connect control the output of standard plotting functions such as ``plot`` and ``hist`` using sliders and other
-control widgets. When using the ``ipympl`` backend these functions will leverage ipywidgets for the controls, otherwise they
-will use the builtin Matplotlib widgets.
+Control the output of standard plotting functions such as ``plot`` and ``hist`` using sliders and other
+widgets. When using the ``ipympl`` backend these functions will leverage ipywidgets for the controls, otherwise they
+will use the built-in Matplotlib widgets.
 
 .. currentmodule:: mpl_interactions
 .. autosummary::
@@ -39,7 +39,7 @@ Functions that will be useful irrespective of backend.
 utilities
 ---------
 
-Functions that make it a bit more convenient to do some things in matplotlib.
+Functions that make some features in Matplotlib a bit more convenient.
 
 .. currentmodule:: mpl_interactions
 .. autosummary::

--- a/docs/Backends.rst
+++ b/docs/Backends.rst
@@ -5,10 +5,10 @@ Matplotlib Backends
 .. note::
         For discussion of what a Matplotlib backend is see: https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
 
-All the functions in the library will work with any interactive backend to Matplotlib. However, if you are working in a Jupyter
-Notebook then you should make sure to use the `ipympl <https://github.com/matplotlib/ipympl>`_ backend. If you use a different backend
-such as ``qt5agg`` then the builtin Matplotlib widgets will be used instead of ipywidgets widgets. It is trickier to achieve a good
-layout of Matplotlib widgets than ipywidgets widgets so if in a Notebook it is useful to use the ipympl backend by including
+All of the functions in this library will work with any interactive backend to Matplotlib. However, if you are working in a Jupyter
+Notebook then you should make sure to use the `ipympl <https://github.com/matplotlib/ipympl>`_ backend. If you are using a different backend
+(such as ``qt5agg``), then the built-in Matplotlib widgets will be used instead of the ipywidgets widgets. It is trickier to achieve a good
+layout of Matplotlib widgets versus ipywidgets widgets, so if in a Notebook it is best to use the ipympl backend by including
 the `Jupyter Magic <https://ipython.readthedocs.io/en/stable/interactive/magics.html>`_:
 
 .. code-block:: python
@@ -19,9 +19,9 @@ the `Jupyter Magic <https://ipython.readthedocs.io/en/stable/interactive/magics.
 Further options
 ---------------
 
-If you want to use a non-ipympl backend in a jupyter notebook but still want ``ipywidgets`` style sliders then you have a few options.
+If you want to use a non-ipympl backend in a Jupyter Notebook but still want ``ipywidgets`` style sliders then you have a few options.
 
-With ``interactive_plot`` and ``interactive_hist`` you can pass ``force_ipywidgets=True``
+* With ``interactive_plot`` and ``interactive_hist`` you can pass ``force_ipywidgets=True``
 
 .. code-block:: python
 
@@ -36,14 +36,14 @@ With ``interactive_plot`` and ``interactive_hist`` you can pass ``force_ipywidge
         return np.sin(x*tau)*x**beta
     fig, ax, sliders = interactive_plot(f, x=x, tau = tau, beta = beta, force_ipywidgets=True)
 
-will result in sliders in the notebook but the plot in a ``qt`` window:
+This will result in sliders in the notebook, but the plot will be in a ``qt`` window:
 
 .. image:: _static/force-ipywidgets.png
 
 
-You can also explicitly set whether to use maptlotlib sliders or not with the ``use_ipywidgets`` argument
-to :meth:`~mpl_interactions.interactive_plot_factory`. If ``None`` then the funciton will try to infer whether
-to use ipywidgets or not. However if you set it ``False`` then you will be able to use Matplotlib sliders in the notebook.
+* You can also explicitly set whether to use Matplotlib sliders or not with the ``use_ipywidgets`` 
+argument :meth:`~mpl_interactions.interactive_plot_factory`. If ``None`` then the funciton will try to infer whether
+to use ipywidgets or not. By setting the argument to ``False`` then you will be able to use Matplotlib sliders in the notebook.
 
 .. code-block:: python
 


### PR DESCRIPTION
## Final Adjustments to Documentation

Finishing Issue #35 by addressing Matplotlib Backends page and API page.

- Adjustments made for grammar, punctuation, style guide, and readability
- **note** Could not "find" the API page table text; need to add a period after description under `pyplot: Interactive_plot` and `utilities: Figure`

Issue Status: 
✔   README
✔   Index
✔   Installation
✔   Matplotlib Backends
**to do:** Comparison to ipywidgets
✔   API
**to do:** Examples
✔   Gallery - n/a
✔   Contributing
