### PR TITLE
Heatmap slicer fixes

### DIFF
--- a/mpl_interactions/generic.py
+++ b/mpl_interactions/generic.py
@@ -118,7 +118,7 @@ def heatmap_slicer(X,Y,heatmaps, slices='horizontal',heatmap_names = None,max_co
         axes[horiz_axis].legend()
 
     def update_lines(event):
-        if event.inaxes is not None:
+        if event.inaxes in axes[:-num_line_axes]:
             for i,lines in enumerate(hlines):
                 y_idx = nearest_idx(Y,event.ydata)
                 lines[0].set_ydata(Y[y_idx])

--- a/mpl_interactions/generic.py
+++ b/mpl_interactions/generic.py
@@ -111,23 +111,25 @@ def heatmap_slicer(X,Y,heatmaps, slices='horizontal',heatmap_names = None,max_co
         ax.pcolormesh(X,Y,heatmaps[i],shading=shading)
         ax.set_xlabel(labels[0])
         ax.set_title(heatmap_names[i])
-        xy_shape = (Y.shape[0], X.shape[0])
         hmap_shape = asanyarray(heatmaps[i]).shape
-        same_shape = xy_shape == hmap_shape
-        if same_shape:
-            x = X
-            y = Y
-        else:
-            x = x_centered
-            y = y_centered
 
         if i > 0:
             ax.set_yticklabels([])
         if horiz:
+            same_shape = X.shape[0] == hmap_shape[1]
+            if same_shape:
+                x = X
+            else:
+                x = x_centered
             data_line = axes[horiz_axis].plot(x,heatmaps[i,init_idx,:],label=f"{heatmap_names[i]}")[0]
             hlines.append((same_shape, ax.axhline(Y[init_idx],color=linecolor),data_line))
 
         if vert:
+            same_shape = Y.shape[0] == hmap_shape[0]
+            if same_shape:
+                y = Y
+            else:
+                y = y_centered
             data_line = axes[vert_axis].plot(y,heatmaps[i,:,init_idx],label=f"{heatmap_names[i]}")[0]
             vlines.append((same_shape, ax.axvline(X[init_idx],color=linecolor), data_line))
 

--- a/mpl_interactions/generic.py
+++ b/mpl_interactions/generic.py
@@ -2,9 +2,11 @@ from matplotlib.pyplot import subplots, close
 from matplotlib import get_backend
 from matplotlib.widgets import LassoSelector
 from matplotlib.path import Path
-from numpy import swapaxes, asarray, min, max
+from numpy import swapaxes, asarray, asanyarray, min, max
 import numpy as np
 from .utils import nearest_idx, ioff, figure
+from matplotlib import __version__ as mpl_version
+from packaging import version
 
 # functions that are methods
 __all__ = [
@@ -92,19 +94,42 @@ def heatmap_slicer(X,Y,heatmaps, slices='horizontal',heatmap_names = None,max_co
     vlines = []
     init_idx = 0
     axes[0].set_ylabel(labels[1])
+    X = asarray(X)
+    Y = asarray(Y)
+    # mpl pcolormesh from verison 3.3+ handles len(X), len(Y) equal to Z shape
+    # differently than <2. (Unquestionably better, but different enough to justify a shim)
+    # https://github.com/matplotlib/matplotlib/pull/16258
+    mpl_gr_33 = version.parse(mpl_version) >= version.parse("3.3")
+    if mpl_gr_33:
+        shading = 'auto'
+    else:
+        shading = 'flat'
+
+    x_centered = X[:-1] + (X[1:] - X[:-1])/2
+    y_centered = Y[:-1] + (Y[1:] - Y[:-1])/2
     for i,ax in enumerate(axes[:-num_line_axes]):
-        ax.pcolormesh(X,Y,heatmaps[i])
+        ax.pcolormesh(X,Y,heatmaps[i],shading=shading)
         ax.set_xlabel(labels[0])
         ax.set_title(heatmap_names[i])
-        if i>0:
-            ax.set_yticklabels([])
+        xy_shape = (Y.shape[0], X.shape[0])
+        hmap_shape = asanyarray(heatmaps[i]).shape
+        same_shape = xy_shape == hmap_shape
+        if same_shape:
+            x = X
+            y = Y
+        else:
+            x = x_centered
+            y = y_centered
 
+        if i > 0:
+            ax.set_yticklabels([])
         if horiz:
-            data_line = axes[horiz_axis].plot(X,heatmaps[i,init_idx,:],label=f"{heatmap_names[i]}")[0]
-            hlines.append((ax.axhline(Y[init_idx],color=linecolor),data_line))
+            data_line = axes[horiz_axis].plot(x,heatmaps[i,init_idx,:],label=f"{heatmap_names[i]}")[0]
+            hlines.append((same_shape, ax.axhline(Y[init_idx],color=linecolor),data_line))
+
         if vert:
-            data_line = axes[vert_axis].plot(Y,heatmaps[i,:,init_idx],label=f"{heatmap_names[i]}")[0]
-            vlines.append((ax.axvline(X[init_idx],color=linecolor),data_line))
+            data_line = axes[vert_axis].plot(y,heatmaps[i,:,init_idx],label=f"{heatmap_names[i]}")[0]
+            vlines.append((same_shape, ax.axvline(X[init_idx],color=linecolor), data_line))
 
     minimum = min(heatmaps)
     maximum = max(heatmaps)
@@ -117,16 +142,39 @@ def heatmap_slicer(X,Y,heatmaps, slices='horizontal',heatmap_names = None,max_co
         axes[horiz_axis].set_ylim([minimum,maximum])
         axes[horiz_axis].legend()
 
+    def _gen_idxs(orig, centered, same_shape, event_data):
+        """
+        is there a better way? probably, but this gets the job done
+        so here we are...
+        """
+        if same_shape:
+            data_idx = nearest_idx(orig, event_data)
+            if mpl_gr_33:
+                disp_idx = nearest_idx(orig, event_data)
+                arr = orig
+            else:
+                disp_idx = nearest_idx(centered, event_data)
+                arr = centered
+        else:
+            disp_idx = nearest_idx(centered, event_data)
+            data_idx = nearest_idx(centered, event_data)
+            arr = centered
+        return arr, data_idx, disp_idx
+
     def update_lines(event):
         if event.inaxes in axes[:-num_line_axes]:
-            for i,lines in enumerate(hlines):
-                y_idx = nearest_idx(Y,event.ydata)
-                lines[0].set_ydata(Y[y_idx])
-                lines[1].set_ydata(heatmaps[i,y_idx,:])
-            for i,lines in enumerate(vlines):
-                x_idx = nearest_idx(X,event.xdata)
-                lines[0].set_xdata(X[x_idx])
-                lines[1].set_ydata(heatmaps[i,:,x_idx])
+            y = None
+            for i,(same_shape, display_line, data_line) in enumerate(hlines):
+                if y is None:
+                    y, data_idx, disp_idx = _gen_idxs(Y, y_centered, same_shape, event.ydata)
+                display_line.set_ydata(y[disp_idx])
+                data_line.set_ydata(heatmaps[i, data_idx])
+            x = None
+            for i,(same_shape, display_line, data_line) in enumerate(vlines):
+                if x is None:
+                    x, data_idx, disp_idx = _gen_idxs(X, x_centered, same_shape, event.xdata)
+                display_line.set_xdata(x[disp_idx])
+                data_line.set_ydata(heatmaps[i, :, data_idx])
         fig.canvas.draw_idle()
     if interaction_type == 'move':
         fig.canvas.mpl_connect('motion_notify_event',update_lines) 


### PR DESCRIPTION
Closes: https://github.com/ianhi/mpl-interactions/issues/88
Closes: https://github.com/ianhi/mpl-interactions/issues/92
See https://matplotlib.org/3.3.1/gallery/images_contours_and_fields/pcolormesh_grids.html for the improved 'nearest' argument to pcolormesh as well as the discussion with the problems with the old version here: https://github.com/matplotlib/matplotlib/pull/16258


```python
%matplotlib widget
import matplotlib.pyplot as plt
import numpy as np
from mpl_interactions import heatmap_slicer
def _annotate(ax, x, y):
    # this all gets repeated below:
    X, Y = np.meshgrid(x, y)
    ax.plot(X.flat, Y.flat, 'o', color='m')
X = np.linspace(0, 10, 11)
Y = np.linspace(0, 5, 11)
Z = np.random.randn(10,10 )
```
### Results with mpl < 3.3
**same sizes**
```python
fig, axes = heatmap_slicer(X[:-1],Y[:-1],Z, slices='vertical')
_annotate(axes[0],X[:-1],Y[:-1])
```
![image](https://user-images.githubusercontent.com/10111092/91256400-3bc0de80-e735-11ea-9330-0ec2819d7e47.png)

**X and Y are 1 one bigger**
```python
fig, axes = heatmap_slicer(X,Y,Z)
_annotate(axes[0],X,Y)
```
![image](https://user-images.githubusercontent.com/10111092/91256783-3fa13080-e736-11ea-881e-c2c70d130ed1.png)

## >= 3.3
**same size:**
![image](https://user-images.githubusercontent.com/10111092/91256855-695a5780-e736-11ea-8c2a-de4462bbe6cc.png)

**diff sizes**

![image](https://user-images.githubusercontent.com/10111092/91256875-7c6d2780-e736-11ea-91d9-d28c096e9458.png)
