### PR TITLE
Webdesign

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,35 @@
+body {
+    background: #fafafa;
+    font-family: "Georgia", Times, serif;
+    font-size: 14px;
+    color: black;
+}
+
+.wy-nav-side {
+    font-family: "Georgia", Times, serif;
+    font-size: 13px;
+    color: black;
+    background: #fafafa;
+}
+
+.wy-side-nav-search, .wy-nav-top {
+    background: #fafafa;
+    color: black
+}
+
+a.icon.icon-home {
+    color: #11557C;
+}
+
+a.reference.internal {
+    font-size: 13px;
+    color: #43464b;
+}
+
+.wy-nav-content {
+    background: #fafafa;
+}
+
+.wy-content-wrap {
+    background: #fafafa;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,8 @@ nbsphinx_execute_arguments = [
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_css_files ] ['css/custom.css']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ In particular, you can:
 
 To achieve this, mpl_interactions provides:
 
-* A way to control the output of pyplot functions (e.g. ``plot`` and ``hist``) with sliders
+* A way to control the output of pyplot functions (e.g. ``plot`` and ``hist``) with sliders.
 * A function to compare horizontal and vertical slices of heatmaps.
 * A function allowing zooming using the scroll wheel.
 


### PR DESCRIPTION
## PR for changes to web design and layout

### Files changed:  
- conf.py
- index.rst
- _new_ custom.css file

No associated Issue. 

### Message :

Hi @ianhi!

You mentioned before I could "mess around" with the Sphinx design. I made some changes and additions to the layout, let me know what you think. I used [Alabaster](https://alabaster.readthedocs.io/en/latest/) and [Write the Docs](https://www.writethedocs.org/) for thematic context. The colour scheme is based on Matpotlib's icon (HEX 11557C) and the blue/green of the python code. The background (HEX fafafa RBG 250) is a tone based off the Sphinx margin grey (HEX efefef RBG 239). 

Also, the `cmd` guide you left in the last PR worked, and my fork is now up to date with the repo 👍🏻 

Cheers,
Sam.