### PR TITLE
Update compare-to-ipywidgets.rst

### DIFF
--- a/docs/compare-to-ipywidgets.rst
+++ b/docs/compare-to-ipywidgets.rst
@@ -10,36 +10,36 @@ Performance
 .. note::
     This explanation is built on the description here: `matplotlib/ipympl#36 (comment) <https://github.com/matplotlib/ipympl/issues/36#issuecomment-361234270>`_
 
-The ipywidgets functions expect the entire output to be regenerated everytime the slider value changes. This means that
-these functions will work best with the inline backend. In fact they even have some `special casing <https://github.com/jupyter-widgets/ipywidgets/blob/6be18d9b75353f7b4a1c328c6ea06d8959f978f6/ipywidgets/widgets/interaction.py#L230>`_
-to better support the inline backend. Unfortunately this does not work well with the interacive ``ipympl`` backend which
-expects to be shown only once and then updated with Matplotlib methods as controls change. The result of this is that you will often end up making
-many new figures or recreating the the entire plot every time the sliders change values. 
+The ipywidgets functions expect the entire output to be regenerated every time a slider value changes. This means ipywidgets functions will work best with 
+the ``inline`` backend. In fact, some `special casing <https://github.com/jupyter-widgets/ipywidgets/blob/6be18d9b75353f7b4a1c328c6ea06d8959f978f6/ipywidgets/widgets/interaction.py#L230>`_
+is even available to better support the inline backend. Unfortunately this process does not work well with the interacive ``ipympl`` backend. The ``ipympl`` backend 
+expects to be shown only once, then updated with Matplotlib methods as controls change. What results is you needing to make
+multiple new figures---or recreate the entire plot---every time a slider value changes. 
 
-You can get around these performance issues by using the ``interact`` function and having the called function use the Matplotlib updating methods 
-such as `line.set_data`. Unfortunately you then end up needing to remember how to do this as well find that you are repeating yourself.
-This was the initial motivation for this library and brings us to the reason of convenience.
+It is possible to get around these performance issues by using the ``interact`` function and setting the called function to use Matplotlib updating methods 
+(such as ``line.set_data``). However in this case, not only do you need to remember how to do this, but over time you will find you are repeating yourself.
+Reducing these performance barriers was the initial motivation for the mpl_interactions library, and also brings us to the reason of convenience.
 
 Portability
 -----------
 
-mpl_interactions will make use of the widgets provided by ipywidgets if they are available, but unlike interactive output, it will
-work if called from a script or an (i)python repl by falling back to the builtin Matplotlib
-`widgets <https://matplotlib.org/api/widgets_api.html?highlight=widgets#module-matplotlib.widgets>`_
+mpl_interactions will make use of the widgets provided by ipywidgets if they are available. Unlike interactive output, it will still 
+work if called from a script or an (i)python reply by falling back to the built in Matplotlib
+`widgets <https://matplotlib.org/api/widgets_api.html?highlight=widgets#module-matplotlib.widgets>`_.
 
 Convenience
 -----------
 
-With **ipywidgets.interact** you are responsible for generating the data to plot, and for handling the logic to update the plot.
+With the interact function (**ipywidgets.interact**) you are responsible for generating the data to plot, and for handling the logic to update the plot.
 
 
 1. ``f(x,...) => y``
 2. Plotting logic (``plt.plot``, ``fig.cla``, ``ax.set_ylim``, etc)
 
-In contrast **mpl_interactions** only requires you specify the data you want to plot and will handle the creation and updating of the plot for you. 
+In contrast, mpl_interactions only requires you specify the data you want to plot and will handle the plot creation and updating for you. 
 
-Additionally there are multiple valid strategies for choosing what selection widgets to create for a parameter. As a general
-framework the choices made by ipywidgets are not always ideal for plotting scientific data. Unencumbered by generality mpl-interactions makes
+Additionally, there are multiple valid strategies for choosing what selection widgets to create for a parameter. As a general
+framework the choices made by ipywidgets are not always ideal for plotting scientific data. Unencumbered by generality, mpl_interactions makes
 several slightly different choices that are more plotting focused.
 
 
@@ -48,14 +48,14 @@ Differences in generated widgets
 
 .. contents:: :local:
 
-**tuple of floats**
+Tuple of floats
 """""""""""""""""""
 
-Both mpl-interactions and ipywidgets will generate a slider. However, mpl-interactions will use ``np.linspace``
+Both mpl_interactions and ipywidgets will generate a slider. However, mpl_interactions will use ``np.linspace``
 and ipywidgets will use ``np.arange``.
 
 
-Comparison of the generated widget for ``two_tuple = (1., 5)`` and ``three_tuple = (0., 1250, 100)``
+Here is a comparison of the generated widget for ``two_tuple = (1., 5)`` and ``three_tuple = (0., 1250, 100)``:
 
 
 **mpl-interactions**
@@ -87,13 +87,13 @@ Comparison of the generated widget for ``two_tuple = (1., 5)`` and ``three_tuple
         pass
     _ = interact(f, two_tuple=(1., 5), three_tuple=(0., 1250, 100))
 
-numpy array or list
+NumPy array or list
 """""""""""""""""""
-ipywidgets will assume these are categoricals. mpl-interactions will try to make a slider for the values.
+ipywidgets will assume a NumPy array or list are categoricals. mpl_interactions will attempt to make a slider for the values.
 
-For example here are what each will create for ``np.linspace(-5,5,100)``
+For example, here is what ipywidgets and mpl_interactions will create for ``np.linspace(-5,5,100)``:
 
-**mpl-interactions**
+**mpl_interactions**
 
 .. jupyter-execute::
     :hide-code:
@@ -116,14 +116,15 @@ For example here are what each will create for ``np.linspace(-5,5,100)``
 Single number
 """""""""""""
 
-for ``param = 10.``
+In the context of a single number, for example, ``param = 10.``:
 
 **mpl_interactions**
 
-Treats the parameter as fixed
+Treats the parameter as fixed.
 
 **ipywidgets**
-Creates a slider with a range of ``[-10,+3*10]``
+
+Creates a slider with a range of ``[-10,+3*10]``.
 
 .. jupyter-execute::
     :hide-code:


### PR DESCRIPTION
## Documentation on "Comparison to ipywidgets" page

Adjustments for readability; final steps of Issue #35 and some adjustments from Issue #63

- Adjustments made for grammar, readability, capitalization, and punctuation
- Adjustments for style guide (ex: mpl-interactions to mpl_interactions, etc.)
- Fixed remaining single to double backticks
- Fixed "The first entry in this toc is slightly bolder: [source](https://mpl-interactions.readthedocs.io/en/latest/compare-to-ipywidgets.html#differences-in-generated-widgets)"

#### Did not (_could not_) address:

- two tuple description
- float and non-float tuples

#### Issue Status:
✔ README
✔ Index
✔ Installation
✔ Matplotlib Backends
✔ Comparison to ipywidgets
✔ API
**to do:** Examples
✔ Gallery - n/a
✔ Contributing