### PR TITLE
allow embedding heatmap_slicer

### DIFF
--- a/examples/embed_heatmap_slicer_tk.py
+++ b/examples/embed_heatmap_slicer_tk.py
@@ -1,0 +1,58 @@
+"""
+based on https://matplotlib.org/3.1.0/gallery/user_interfaces/embedding_in_tk_sgskip.html
+special thanks to @tacaswell for helping on the matplotlib discourse:
+https://discourse.matplotlib.org/t/mpl-iteractions-with-gui-outside-of-jupyter-notebooks/21523/6
+"""
+
+import tkinter
+
+import numpy as np
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+
+# Implement the default Matplotlib key bindings.
+from matplotlib.figure import Figure
+from matplotlib.widgets import Slider
+from mpl_interactions import heatmap_slicer
+
+root = tkinter.Tk()
+root.wm_title("Embedding heatmap_slicer Tk gui")
+
+fig = Figure(figsize=(5, 4), dpi=100)
+
+
+canvas = FigureCanvasTkAgg(fig, master=root)  # A tk.DrawingArea.
+canvas.draw()
+canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
+
+toolbar = NavigationToolbar2Tk(canvas, root)
+toolbar.update()
+canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
+
+
+x = np.linspace(0, np.pi, 100)
+y = np.linspace(0, 10, 200)
+X, Y = np.meshgrid(x, y)
+data1 = np.sin(X) + np.exp(np.cos(Y))
+data2 = np.cos(X) + np.exp(np.sin(Y))
+_, axes = heatmap_slicer(
+    x,
+    y,
+    (data1, data2),
+    slices="both",
+    heatmap_names=("dataset 1", "dataset 2"),
+    labels=("Some wild X variable", "Y axis"),
+    interaction_type="move",
+    fig=fig,
+)
+
+
+def _quit():
+    root.quit()  # stops mainloop
+    root.destroy()  # this is necessary on Windows to prevent
+    # Fatal Python Error: PyEval_RestoreThread: NULL tstate
+
+
+button = tkinter.Button(master=root, text="Quit", command=_quit)
+button.pack(side=tkinter.BOTTOM)
+
+tkinter.mainloop()

--- a/mpl_interactions/generic.py
+++ b/mpl_interactions/generic.py
@@ -32,6 +32,7 @@ def heatmap_slicer(
     linecolor="k",
     labels=("X", "Y"),
     interaction_type="move",
+    fig=None,
 ):
 
     """
@@ -69,6 +70,10 @@ def heatmap_slicer(
     labels : (string, string), optional
     interaction_type : str
         Update on mouse movement or mouse click. Options are {'move','click'}
+    fig : matplotlib figure, optional
+        figure to use for the heatmap_slicer. Useful when embedding into a gui.
+        If you are embedding into a gui make sure you set up the gui canvas first
+        and then pass the figure to this function
 
     Returns
     -------
@@ -108,7 +113,11 @@ def heatmap_slicer(
     else:
         raise ValueError(f"heatmaps must be 2D or 3D but is {heatmaps.ndim}D")
 
-    fig, axes = subplots(1, num_axes, figsize=figsize)
+    if fig is None:
+        fig, axes = subplots(1, num_axes, figsize=figsize)
+    else:
+        axes = fig.subplots(1, num_axes)
+
     hlines = []
     vlines = []
     init_idx = 0


### PR DESCRIPTION
allows passing a figure instance to heatmap_slicer so that it can be embedded into a gui. I made an example but ideally this will make it into the docs one day as well. Perhaps as a standalone embedding section?

attn: @drfeinberg I think this fixes your issue. 
![heatmap_embed](https://user-images.githubusercontent.com/10111092/93161414-80aab600-f6e0-11ea-8f2f-b91742cc9cf7.gif)


based on helpful discussions here: https://discourse.matplotlib.org/t/mpl-iteractions-with-gui-outside-of-jupyter-notebooks/21523/5