### PR TITLE
allow hyperslicers to share controls

### DIFF
--- a/mpl_interactions/_version.py
+++ b/mpl_interactions/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 9, 1)
+version_info = (0, 10, 0)
 __version__ = ".".join(map(str, version_info))

--- a/mpl_interactions/controller.py
+++ b/mpl_interactions/controller.py
@@ -56,7 +56,7 @@ class Controls:
         self._update_funcs = defaultdict(list)
         self.add_kwargs(kwargs, slider_formats, play_buttons)
 
-    def add_kwargs(self, kwargs, slider_formats=None, play_buttons=None):
+    def add_kwargs(self, kwargs, slider_formats=None, play_buttons=None, allow_duplicates=False):
         """
         If you pass a redundant kwarg it will just be overwritten
         maybe should only raise a warning rather than an error?
@@ -83,7 +83,10 @@ class Controls:
         if self.use_ipywidgets:
             for k, v in kwargs.items():
                 if k in self.params:
-                    raise ValueError("can't overwrite an existing param in the controller")
+                    if allow_duplicates:
+                        continue
+                    else:
+                        raise ValueError("can't overwrite an existing param in the controller")
                 # create slider
                 self.params[k], control = kwarg_to_ipywidget(
                     k,
@@ -101,6 +104,11 @@ class Controls:
                 self.control_figures.append(mpl_layout[0])
                 widget_y = 0.05
                 for k, v in kwargs.items():
+                    if k in self.params:
+                        if allow_duplicates:
+                            continue
+                        else:
+                            raise ValueError("Can't overwrite an existing param in the controller")
                     self.params[k], control, cb, widget_y = kwarg_to_mpl_widget(
                         mpl_layout[0],
                         mpl_layout[1:],
@@ -187,16 +195,18 @@ class Controls:
         ipy_display(self.vbox)
 
 
-def gogogo_controls(kwargs, controls, display_controls, slider_formats, play_buttons):
+def gogogo_controls(
+    kwargs, controls, display_controls, slider_formats, play_buttons, allow_dupes=False
+):
     if controls:
         if isinstance(controls, tuple):
             # it was indexed by the user when passed in
             extra_keys = controls[1]
             controls = controls[0]
-            controls.add_kwargs(kwargs, slider_formats, play_buttons)
+            controls.add_kwargs(kwargs, slider_formats, play_buttons, allow_duplicates=allow_dupes)
             params = {k: controls.params[k] for k in list(kwargs.keys()) + list(extra_keys)}
         else:
-            controls.add_kwargs(kwargs, slider_formats, play_buttons)
+            controls.add_kwargs(kwargs, slider_formats, play_buttons, allow_duplicates=allow_dupes)
             params = controls.params
         return controls, params
     else:

--- a/mpl_interactions/generic.py
+++ b/mpl_interactions/generic.py
@@ -656,7 +656,7 @@ def hyperslicer(
             kwargs[name] = np.arange(arr.shape[i])
 
     controls, params = gogogo_controls(
-        kwargs, controls, display_controls, slider_format_strings, play_buttons
+        kwargs, controls, display_controls, slider_format_strings, play_buttons, allow_dupes=True
     )
 
     def update(params, indices, cache):


### PR DESCRIPTION
allows this to work as expected:

```python
%matplotlib ipympl
import matplotlib.pyplot as plt
from mpl_interactions import hyperslicer
from skimage.data import binary_blobs

arr1 = []
arr2 = []
for i in range(10):
    arr1.append(binary_blobs(length=128,n_dim=2))
    arr2.append(binary_blobs(length=128,n_dim=2))
plt.figure()
controls = hyperslicer(arr1, play_buttons=True, cmap='jet')
_ = hyperslicer(arr2, play_buttons=True,alpha=.5, controls = controls)
```