### PR TITLE
fix sci when not psased the current axis

### DIFF
--- a/mpl_interactions/_version.py
+++ b/mpl_interactions/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 13, 0)
+version_info = (0, 13, 1)
 __version__ = ".".join(map(str, version_info))

--- a/mpl_interactions/generic.py
+++ b/mpl_interactions/generic.py
@@ -6,7 +6,7 @@ import numpy as np
 from matplotlib import get_backend
 from matplotlib.colors import TABLEAU_COLORS, XKCD_COLORS, to_rgba_array
 from matplotlib.path import Path
-from matplotlib.pyplot import close, subplots, sci
+from matplotlib.pyplot import close, subplots
 from matplotlib.widgets import LassoSelector
 from numpy import asanyarray, asarray, max, min, swapaxes
 
@@ -717,7 +717,9 @@ def hyperslicer(
         url=url,
     )
     # this is necessary to make calls to plt.colorbar behave as expected
-    sci(im)
+    # i know it's bad news to use private methods :(
+    # but idk how else to accomplish being a psuedo-pyplot
+    ax._sci(im)
     if title is not None:
         ax.set_title(title.format(**params))
 

--- a/mpl_interactions/pyplot.py
+++ b/mpl_interactions/pyplot.py
@@ -7,7 +7,7 @@ from matplotlib.cbook.deprecation import deprecated
 from matplotlib.collections import PatchCollection
 from matplotlib.colors import to_rgba_array
 from matplotlib.patches import Rectangle
-from matplotlib.pyplot import sca, sci
+from matplotlib.pyplot import sca
 
 from .controller import Controls, gogogo_controls
 
@@ -578,7 +578,7 @@ def interactive_scatter(
     )
     # this is necessary to make calls to plt.colorbar behave as expected
     sca(ax)
-    sci(scatter)
+    ax._sci(scatter)
 
     return controls
 
@@ -706,8 +706,10 @@ def interactive_imshow(
         resample=resample,
         url=url,
     )
-    # this is necessary to make calls to plt.colorbar behave as expected
-    sci(im)
+
+    # i know it's bad news to use private methods :(
+    # but idk how else to accomplish being a psuedo-pyplot
+    ax._sci(im)
     return controls
 
 


### PR DESCRIPTION
previously doing this would break:
```
fig, axs = plt.subplots(1, 2)
iplt.imshow(img, ax=axs[0])
```
bc sci would end up being called on axs[1] which doesn't have anything in it

This is not great bc uses a private method - perhaps ask if it could be made not private?