### PR TITLE
vmin_vmax for hyperslicer

### DIFF
--- a/mpl_interactions/_version.py
+++ b/mpl_interactions/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 15, 0)
+version_info = (0, 16, 0)
 __version__ = ".".join(map(str, version_info))

--- a/mpl_interactions/generic.py
+++ b/mpl_interactions/generic.py
@@ -497,6 +497,7 @@ def hyperslicer(
     alpha=None,
     vmin=None,
     vmax=None,
+    vmin_vmax=None,
     origin=None,
     extent=None,
     autoscale_cmap=True,
@@ -687,6 +688,10 @@ def hyperslicer(
     for a in args:
         if a is not None:
             kwargs[a[0]] = a[1]
+    if vmin_vmax is not None:
+        if isinstance(vmin_vmax, tuple) and not isinstance(vmin_vmax[0], str):
+            vmin_vmax = ("r", *vmin_vmax)
+        kwargs["vmin_vmax"] = vmin_vmax
 
     controls, params = gogogo_controls(
         kwargs,
@@ -697,6 +702,16 @@ def hyperslicer(
         extra_ctrls,
         allow_dupes=True,
     )
+    if vmin_vmax is not None:
+        params.pop("vmin_vmax")
+        params["vmin"] = controls.params["vmin"]
+        params["vmax"] = controls.params["vmax"]
+
+        def vmin(**kwargs):
+            return kwargs["vmin"]
+
+        def vmax(**kwargs):
+            return kwargs["vmax"]
 
     def update(params, indices, cache):
         if title is not None:


### PR DESCRIPTION
```python
%matplotlib widget
import numpy as np
import matplotlib.pyplot as plt
import mpl_interactions.ipyplot as iplt
from mpl_interactions import hyperslicer
arr = np.random.randn(5, 100,100)
fig, axs = plt.subplots(1,2)
ctrls = hyperslicer(arr, ax=axs[0], vmin_vmax=("r", arr.min(), arr.max()))
def f(axis0):
    return arr[axis0].flatten()
_ = iplt.hist(f, controls = ctrls['axis0'], ax=axs[1])
_ = iplt.axvline(ctrls['vmin'],ax = axs[1], color='k')
_ = iplt.axvline(ctrls['vmax'],ax = axs[1], color='k')
```

