### PR TITLE
Fix floating point index for latest numpy

### DIFF
--- a/mpl_interactions/_version.py
+++ b/mpl_interactions/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 16, 0)
+version_info = (0, 16, 1)
 __version__ = ".".join(map(str, version_info))

--- a/mpl_interactions/controller.py
+++ b/mpl_interactions/controller.py
@@ -150,7 +150,7 @@ class Controls:
                     self.params["vmin"] = self.params[key][0]
                     self.params["vmax"] = self.params[key][1]
             else:
-                self.params[key] = values[change["new"]]
+                self.params[key] = values[int(change["new"])]
         self.indices[key] = change["new"]
         if self.use_cache:
             cache = {}

--- a/mpl_interactions/controller.py
+++ b/mpl_interactions/controller.py
@@ -150,6 +150,8 @@ class Controls:
                     self.params["vmin"] = self.params[key][0]
                     self.params["vmax"] = self.params[key][1]
             else:
+                # int casting due to a bug in numpy < 1.19
+                # see https://github.com/ianhi/mpl-interactions/pull/155
                 self.params[key] = values[int(change["new"])]
         self.indices[key] = change["new"]
         if self.use_cache:

--- a/mpl_interactions/helpers.py
+++ b/mpl_interactions/helpers.py
@@ -483,7 +483,7 @@ def create_mpl_selection_slider(ax, label, values, slider_format_string):
     slider = mwidgets.Slider(ax, label, 0, len(values), valinit=0, valstep=1)
 
     def update_text(val):
-        slider.valtext.set_text(slider_format_string.format(values[val]))
+        slider.valtext.set_text(slider_format_string.format(values[int(val)]))
 
     # make sure the initial value also gets formatted
     update_text(0)


### PR DESCRIPTION
The example on the homepage does not work on the latest numpy due to the removal of the deprecated feature of indexing based on floating points.  This PR fixes that problem.  There may be more places in the code where this bug occurs - I don't know the code very well so I only fixed the ones that pertained to my use case