### PR TITLE
Scatter marker

### DIFF
--- a/mpl_interactions/pyplot.py
+++ b/mpl_interactions/pyplot.py
@@ -431,7 +431,8 @@ def interactive_scatter(
     s : float, array-like, function, or index controls object
         valid input to plt.scatter, or a function
     marker : MarkerStyle, default: rcParams["scatter.marker"] (default: 'o')
-       The marker style. marker can be either an instance of the class or the text shorthand for a particular marker. See matplotlib.markers for more information about marker styles.
+        The marker style. marker can be either an instance of the class or the text shorthand for a particular marker.
+        See matplotlib.markers for more information about marker styles.
     alpha : float, None, or function(s), broadcastable
         Affects all scatter points. This will compound with any alpha introduced by
         the ``c`` argument

--- a/mpl_interactions/pyplot.py
+++ b/mpl_interactions/pyplot.py
@@ -399,6 +399,7 @@ def interactive_scatter(
     y=None,
     s=None,
     c=None,
+    marker=None,
     cmap=None,
     vmin=None,
     vmax=None,
@@ -429,6 +430,8 @@ def interactive_scatter(
         valid input to plt.scatter
     s : float, array-like, function, or index controls object
         valid input to plt.scatter, or a function
+    marker : MarkerStyle, default: rcParams["scatter.marker"] (default: 'o')
+       The marker style. marker can be either an instance of the class or the text shorthand for a particular marker. See matplotlib.markers for more information about marker styles.
     alpha : float, None, or function(s), broadcastable
         Affects all scatter points. This will compound with any alpha introduced by
         the ``c`` argument
@@ -574,6 +577,7 @@ def interactive_scatter(
         y_,
         c=c_,
         s=s_,
+        marker=marker,
         vmin=vmin,
         vmax=vmax,
         cmap=cmap,


### PR DESCRIPTION
marker kwarg from `plt.scatter` was missing so it ended up being passed to the callable that generated the points. 

Works for the simple case of setting the markers to be `x` instead of `o` but not totally clear to me if it would work to pass a callable or array to marker.