### PR TITLE
Start of 3D plots: Basic plot_surface

### DIFF
--- a/mpl_interactions/helpers.py
+++ b/mpl_interactions/helpers.py
@@ -39,6 +39,7 @@ __all__ = [
     "gogogo_display",
     "create_mpl_controls_fig",
     "eval_xy",
+    "eval_xyz",
     "choose_fmt_str",
 ]
 
@@ -254,6 +255,23 @@ def eval_xy(x_, y_, params, cache=None):
     else:
         y = y_
     return np.asanyarray(x), np.asanyarray(y)
+
+def eval_xyz(x, y, z, params, cache=None):
+    # maybe should allow for `y` to not need `x`
+    x_, y_ = eval_xy(x, y, params, cache)
+    
+    if isinstance(z, Callable):
+        if cache is not None:
+            if z in cache:
+                z_ = cache[z]
+            else:
+                z_ = z(x, y, **params)
+        else:
+            z_ = z(x, y, **params)
+    else:
+        z_ = z
+    return x_, y_, np.asanyarray(z_)
+
 
 
 def kwarg_to_ipywidget(key, val, update, slider_format_string, play_button=None):

--- a/mpl_interactions/ipyplot.py
+++ b/mpl_interactions/ipyplot.py
@@ -7,3 +7,4 @@ from .pyplot import interactive_axvline as axvline
 from .pyplot import interactive_title as title
 from .pyplot import interactive_xlabel as xlabel
 from .pyplot import interactive_ylabel as ylabel
+from .pyplot import interactive_plot_surface as plot_surface

--- a/mpl_interactions/mpl_kwargs.py
+++ b/mpl_interactions/mpl_kwargs.py
@@ -1,6 +1,8 @@
 from matplotlib.artist import ArtistInspector
 from matplotlib.collections import Collection
 from matplotlib.image import AxesImage
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
 
 # this is a list of options to Line2D partially taken from
 # https://github.com/matplotlib/matplotlib/blob/f9d29189507cfe4121a231f6ab63539d216c37bd/lib/matplotlib/lines.py#L271
@@ -63,6 +65,7 @@ Line2D_kwargs_list = [
 
 imshow_kwargs_list = ArtistInspector(AxesImage).get_setters()
 collection_kwargs_list = ArtistInspector(Collection).get_setters()
+Poly3D_collection_kwargs_list = ArtistInspector(Poly3DCollection).get_setters()
 
 Text_kwargs_list = [
     "agg_filter",


### PR DESCRIPTION
Quick first pass at implementing `plot_surface` using the `artist.remove` strategy from https://github.com/ianhi/mpl-interactions/issues/89#issuecomment-882816718 

attn: @redeboer this is a rough starting place. If you'd like to work on this you're absolutely welcome to work starting off this branch. I probably will only work on this in occasional spurts as it isn't a pressing need for me. So if you aren't able to work on this but it's something you'd like to be able to use then I'd also be open to releasing it before I clean up having all the arguments be callable and other polish.


One thing I didn't realize previously is that we have to do some shenanigans with the color cycles in order to get the color to stay the same. 


See also: https://github.com/t-makaro/animatplot/pull/57 by  @johnomotani 

TODO:

1. This is far from perfect. In particular most of the parameters can actually be callables (https://matplotlib.org/stable/tutorials/toolkits/mplot3d.html#mpl_toolkits.mplot3d.Axes3D.plot_surface)
2. Currently if `Y` is a callable is must accept `X` as an argument. This probably shouldn't be a hard requirement.
3. Docstring!
4. Docs page?


Final thought: Rewriting the `vmin_vmax` code for the Nth time has me really thinking that perhaps this function approach wasn't really the best. Maybe I should have made my own artist type objects that know how to update themselves. So then there could be a `HasNorm` class that handles all the `vmin_vmax` stuff in one place.