### PR TITLE
allow image-segmenter to applied to an existing axis

### DIFF
--- a/mpl_interactions/_version.py
+++ b/mpl_interactions/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 17, 12)
+version_info = (0, 18, 0)
 __version__ = ".".join(map(str, version_info))

--- a/mpl_interactions/generic.py
+++ b/mpl_interactions/generic.py
@@ -378,6 +378,7 @@ class image_segmenter:
         mask_colors=None,
         mask_alpha=0.75,
         lineprops=None,
+        ax=None,
         figsize=(10, 10),
         **kwargs,
     ):
@@ -400,8 +401,10 @@ class image_segmenter:
         lineprops : dict, default: None
             lineprops passed to LassoSelector. If None the default values are:
             {"color": "black", "linewidth": 1, "alpha": 0.8}
+        ax : `matplotlib.axes.Axes`, optional
+            The axis on which to plot. If *None* a new figure will be created.
         figsize : (float, float), optional
-            passed to plt.figure
+            passed to plt.figure. Ignored if *ax* is given.
         **kwargs
             All other kwargs will passed to the imshow command for the image
         """
@@ -437,11 +440,15 @@ class image_segmenter:
                 self._overlay[idx] = [0, 0, 0, 0]
             else:
                 self._overlay[idx] = self.mask_colors[i - 1]
-        with ioff:
-            self.fig = figure(figsize=figsize)
-            self.ax = self.fig.gca()
-            self.displayed = self.ax.imshow(self._img, **kwargs)
-            self._mask = self.ax.imshow(self._overlay)
+        if ax is not None:
+            self.ax = ax
+            self.fig = self.ax.figure
+        else:
+            with ioff:
+                self.fig = figure(figsize=figsize)
+                self.ax = self.fig.gca()
+        self.displayed = self.ax.imshow(self._img, **kwargs)
+        self._mask = self.ax.imshow(self._overlay)
 
         if lineprops is None:
             lineprops = {"color": "black", "linewidth": 1, "alpha": 0.8}

--- a/mpl_interactions/generic.py
+++ b/mpl_interactions/generic.py
@@ -378,6 +378,8 @@ class image_segmenter:
         mask_colors=None,
         mask_alpha=0.75,
         lineprops=None,
+        lasso_mousebutton="left",
+        pan_mousebutton="middle",
         ax=None,
         figsize=(10, 10),
         **kwargs,
@@ -401,6 +403,11 @@ class image_segmenter:
         lineprops : dict, default: None
             lineprops passed to LassoSelector. If None the default values are:
             {"color": "black", "linewidth": 1, "alpha": 0.8}
+        lasso_mousebutton : str, or int, default: "left"
+            The mouse button to use for drawing the selecting lasso.
+        pan_mousebutton : str, or int, default: "middle"
+            The button to use for `~mpl_interactions.generic.panhandler`. One of 'left', 'middle' or
+            'right', or 1, 2, 3 respectively.
         ax : `matplotlib.axes.Axes`, optional
             The axis on which to plot. If *None* a new figure will be created.
         figsize : (float, float), optional
@@ -453,7 +460,15 @@ class image_segmenter:
         if lineprops is None:
             lineprops = {"color": "black", "linewidth": 1, "alpha": 0.8}
         useblit = False if "ipympl" in get_backend().lower() else True
-        self.lasso = LassoSelector(self.ax, self._onselect, lineprops=lineprops, useblit=useblit)
+        button_dict = {"left": 1, "middle": 2, "right": 3}
+        if isinstance(pan_mousebutton, str):
+            pan_mousebutton = button_dict[pan_mousebutton.lower()]
+        if isinstance(lasso_mousebutton, str):
+            lasso_mousebutton = button_dict[lasso_mousebutton.lower()]
+
+        self.lasso = LassoSelector(
+            self.ax, self._onselect, lineprops=lineprops, useblit=useblit, button=lasso_mousebutton
+        )
         self.lasso.set_visible(True)
 
         pix_x = np.arange(self._img.shape[0])
@@ -461,7 +476,7 @@ class image_segmenter:
         xv, yv = np.meshgrid(pix_y, pix_x)
         self.pix = np.vstack((xv.flatten(), yv.flatten())).T
 
-        self.ph = panhandler(self.fig)
+        self.ph = panhandler(self.fig, button=pan_mousebutton)
         self.disconnect_zoom = zoom_factory(self.ax)
         self.current_class = 1
         self.erasing = False


### PR DESCRIPTION
this is necessary for embedding into a gui. The key thing to do is to attach events to the figure canvas after it has been transformed to the `tk canvas` provided by the gui, otherwise the events are properly registered, or the plot is not properly placed in the layout.

Inspired by searching for usage and noticing https://github.com/john-judge/PhotoLib/blob/7cf936f9446ef01e114deef6e3a8dfa697b5b7f1/pyPhoto21/gui.py so attention @john-judge

Example below:


<details>
 <summary>PySimpleGUI code example</summary>

```python
import numpy as np
import PySimpleGUI as sg

"""
    Embedding the Matplotlib toolbar into your application
"""

from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
from matplotlib.figure import Figure

from mpl_interactions import image_segmenter

# ------------------------------- PySimpleGUI CODE

layout = [
    [sg.T("Graph: y=sin(x)")],
    [sg.B("Toggle Erase Mode"), sg.B("Exit")],
    [sg.T("Controls:")],
    [sg.Canvas(key="controls_cv")],
    [sg.T("Figure:")],
    [
        sg.Column(
            layout=[
                [
                    sg.Canvas(
                        key="fig_cv",
                        # it's important that you set this size
                        size=(300, 800),
                    )
                ]
            ],
            background_color="#DAE0E6",
            pad=(0, 0),
        )
    ],
    [sg.B("Alive?")],
]

window = sg.Window("Graph with controls", layout)

# apply the layout so that the canvas exists for matplotlib to use.
window.finalize()

# Set up the Matplotlib Figure
DPI = 100
fig = Figure((200 * 2 / float(DPI), 800 / float(DPI)), dpi=DPI)
canvas = FigureCanvasTkAgg(fig, master=window["fig_cv"].TKCanvas)  # A tk.DrawingArea.

toolbar = NavigationToolbar2Tk(canvas, window["controls_cv"].TKCanvas)
toolbar.update()
fig.set_size_inches(404 * 2 / float(DPI), 404 / float(DPI))
canvas.draw()
canvas.get_tk_widget().pack(side="right", fill="both", expand=1)

# Set up matplotlib styling
# This won't change each loop
ax = fig.gca()
from imageio import imread

image = imread(
    "https://github.com/matplotlib/matplotlib/raw/v3.3.0/lib/matplotlib/mpl-data/sample_data/ada.png"
)
_ = ax.imshow(image)
segmenter = image_segmenter(image, ax=ax)


while True:
    event, values = window.read()
    print(event, values)
    if event in (sg.WIN_CLOSED, "Exit"):  # always,  always give a way out!
        break
    elif event == "Toggle Erase Mode":
        segmenter.erasing = not segmenter.erasing

window.close()


```
</details>