### PR TITLE
fix unnecessary casting to numpy in ipywidget creation

### DIFF
--- a/mpl_interactions/helpers.py
+++ b/mpl_interactions/helpers.py
@@ -357,7 +357,7 @@ def kwarg_to_ipywidget(key, val, update, slider_format_string, play_button=None)
             raise ValueError(f"{key} is {val.ndim}D but can only be 1D or a scalar")
         if len(val) == 1:
             # don't need to create a slider
-            return val, None
+            return val[0], None
         else:
             # params[key] = val[0]
             label = widgets.Label(value=slider_format_string.format(val[0]))

--- a/tests/test_pyplot.py
+++ b/tests/test_pyplot.py
@@ -120,3 +120,18 @@ def test_imshow_scalars():
 
     fig, ax = plt.subplots()
     iplt.imshow(mask, min_distance=(1, 10), alpha=(0, 1))
+
+
+def test_title():
+    fig, ax = plt.subplots()
+    ctrls = iplt.plot(1, 1, E=3e7)
+    expected = "E=3.00e+07"
+    iplt.title("E={E:.2e}", controls=ctrls)
+    assert not isinstance(ctrls.params["E"], np.ndarray)
+    assert ax.get_title() == expected
+    plt.close()
+    fig, ax = plt.subplots()
+    ctrls = iplt.plot(1, 1, E=np.array([3e7, 3e9]))
+    iplt.title("E={E:.2e}", controls=ctrls)
+    assert ax.get_title() == expected
+    plt.close()


### PR DESCRIPTION
fixes: #214 

need to get the test suite to also run with ipympl backend. maybe as a fixture?