### PR TITLE
Allow using controls as context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,11 +135,4 @@ _build
 # autoapi stuff - may be bad to ignore this idk
 autoapi
 
-# notebooks in the docs folder
-# this is to enable the madness with adding gifs
-docs/examples/tidbits/*.ipynb
-docs/examples/*.ipynb
-docs/examples/*.gif
-docs/*.ipynb
-docs/gallery
-
+_version.py

--- a/docs/examples/context.ipynb
+++ b/docs/examples/context.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9bdc7777-5241-4944-a12b-46f05c894dbe",
+   "metadata": {},
+   "source": [
+    "# Contextmanager for Controls object\n",
+    "\n",
+    "\n",
+    "When you are making a complex interactive visualization you may need to use many `mpl-interactions` functions. One way to do this is to pass `controls=controls` to every function you call. But that's pretty lame because you have to type the same thing out many times. So you can also use `controls` objects as context managers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c34e1ff-3ef3-4090-a2bd-7dcb3701e58b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib ipympl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28ae4a71-a451-4846-be37-161a42d4a18e",
+   "metadata": {},
+   "source": [
+    "## Using all params\n",
+    "\n",
+    "If you want to use all the parameters in a controls object then you can simply do:\n",
+    "```python\n",
+    "with controls:\n",
+    "    # iplt functions here\n",
+    "```\n",
+    "\n",
+    "## Using only a subset of the control's params\n",
+    "You can also use a subset of the params in a context by indexing it with strings.\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "with controls['param-name', 'param-name-2',...]:\n",
+    "    # iplt functions here\n",
+    "```\n",
+    "\n",
+    "## Adding new params from within a context\n",
+    "\n",
+    "You can still add new params from within a controls context:\n",
+    "\n",
+    "```python\n",
+    "with controls:\n",
+    "    iplt.plot(x,f, new_param=np.linspace(0, 1))\n",
+    "```\n",
+    "\n",
+    "\n",
+    "## Example\n",
+    "\n",
+    "Here is an example that demonstrates the various possible behaviors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "852d736e-2839-4b22-9bd5-1e7b4e35a1d9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import mpl_interactions.ipyplot as iplt\n",
+    "\n",
+    "x = np.linspace(0, 2 * np.pi, 1000)\n",
+    "tau = np.linspace(5, 10)\n",
+    "beta = np.linspace(0.25, 1)\n",
+    "delta = np.linspace(0, 0.75)\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "\n",
+    "def f1(tau, beta):\n",
+    "    return np.sin(x * tau) * x * beta\n",
+    "\n",
+    "\n",
+    "def f2(tau, beta):\n",
+    "    return np.sin(x * beta) * x * tau\n",
+    "\n",
+    "\n",
+    "def f2_tau(tau):\n",
+    "    return np.sin(x * 1) * x * tau\n",
+    "\n",
+    "\n",
+    "def f2_tau_delta(tau, delta):\n",
+    "    return np.sin(x * delta) * x * tau\n",
+    "\n",
+    "\n",
+    "# Create the initial object\n",
+    "controls = iplt.plot(f1, \"k--\", tau=tau, beta=beta, label=\"f1\")\n",
+    "\n",
+    "# context with all parameters\n",
+    "with controls:\n",
+    "    iplt.plot(f2, label=\"f2\")\n",
+    "\n",
+    "# adding a new parameter and excluding beta\n",
+    "with controls[\"tau\"]:\n",
+    "    iplt.plot(f2_tau_delta, delta=delta, label=\"f2 tau alpha\")\n",
+    "\n",
+    "# excluding all params except tau\n",
+    "with controls[\"tau\"]:\n",
+    "    iplt.plot(f2_tau, label=\"f2 only tau\")\n",
+    "\n",
+    "_ = plt.legend()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/plot.ipynb
+++ b/docs/examples/plot.ipynb
@@ -207,6 +207,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Or by using controls as a context manager. See {doc}`context` for complete examples of context manager usage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "controls = iplt.plot(x, f1, tau=tau, beta=beta, label=\"f1\")\n",
+    "with controls:\n",
+    "    iplt.plot(x, f2, label=\"f2\")\n",
+    "_ = plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Styling of plot\n",
     "\n",
     "You can either use the figure and axis objects returned by the function, or if the figure is the current active figure the standard {mod}`plt.__ <matplotlib.pyplot>` commands should work as expected. You can also provide explicit plot_kwargs to the {func}`plt.plot() <matplotlib.pyplot.plot>` command that is used internally using the plot_kwargs argument\n",
@@ -341,7 +361,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/examples/usage.ipynb
+++ b/docs/examples/usage.ipynb
@@ -90,7 +90,7 @@
     "controls4 = iplt.plot(x, f, 'o--', tau=tau, beta=beta)\n",
     "```\n",
     "\n",
-    "However, if you run all three of those lines together then you will create three sets of controls. To have sliders affect multiple lines you can pass the controls to the function instead of using keyword arguments."
+    "However, if you run all three of those lines together then you will create three sets of controls. To have sliders affect multiple lines you can pass the controls to the function instead of using keyword arguments. Or you can use the controls object as a contextmanager as described in {doc}`context`."
    ]
   },
   {
@@ -488,7 +488,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,7 @@ contributing
 :maxdepth: 1
 
 examples/usage.ipynb
+examples/context.ipynb
 examples/mpl-sliders.ipynb
 examples/custom-callbacks.ipynb
 examples/animations.ipynb


### PR DESCRIPTION
Allows things like

```python
with controls:
   iplt.plot(f1)
   iplt.plot(f2)
   iplt.plot(f3)
   iplt.plot(f4)
   iplt.plot(f5)
```

Full set of examples here: https://mpl-interactions--223.org.readthedocs.build/en/223/examples/context.html

Curious if any known users (@kmdalton, @jrussell25, @redeboer) have thoughts on this interface. In particular the usage of the `__call__` method and if that's intuitive given that indexing a controls object serves a similar purpose.

~I think I sort of painted myself into a corner here. I think ideally we'd use `()` for specifying specific params, and `[]` for allow users to access and directly modify params, but here we are :(~

Turns out since the result of indexing was never used directly by users (at least I hope not) I can just change what it returns to be more flexible. I considered that indexing should return a child `Controls` object so that indexing returns a subset of the original object like with arrays or dataframes but I think that would complicated to implement as the object creation is tied up with slider generation and whatnot.

I also harbor a vague hope that `ctrls['beta']` would give you an object that lets you set it's value, but that's probably for another day (and also I think will create back-compat issues no matter what)