### PR TITLE
Don't fail on sca

### DIFF
--- a/mpl_interactions/helpers.py
+++ b/mpl_interactions/helpers.py
@@ -13,11 +13,13 @@ except ImportError:
     pass
 from matplotlib import get_backend
 from matplotlib.pyplot import axes, figure, gca, gcf, ioff
+from matplotlib.pyplot import sca as mpl_sca
 from numpy.distutils.misc_util import is_sequence
 
 from .widgets import RangeSlider
 
 __all__ = [
+    "sca",
     "decompose_bbox",
     "update_datalim_from_xy",
     "update_datalim_from_bbox",
@@ -40,6 +42,17 @@ __all__ = [
     "eval_xy",
     "choose_fmt_str",
 ]
+
+
+def sca(ax):
+    """
+    sca that won't fail if figure not managed by pyplot
+    """
+    try:
+        mpl_sca(ax)
+    except ValueError as e:
+        if "not managed by pyplot" not in str(e):
+            raise e
 
 
 def decompose_bbox(bbox):

--- a/mpl_interactions/pyplot.py
+++ b/mpl_interactions/pyplot.py
@@ -13,7 +13,6 @@ import numpy as np
 from matplotlib.collections import PatchCollection
 from matplotlib.colors import to_rgba_array
 from matplotlib.patches import Rectangle
-from matplotlib.pyplot import sca
 
 from .controller import Controls, gogogo_controls, prep_scalars
 from .helpers import (
@@ -27,6 +26,7 @@ from .helpers import (
     kwarg_to_ipywidget,
     kwarg_to_mpl_widget,
     notebook_backend,
+    sca,
     update_datalim_from_bbox,
 )
 from .mpl_kwargs import (

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,9 @@
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-import pytest
+from matplotlib.figure import Figure
 
-from mpl_interactions.helpers import update_datalim_from_bbox, update_datalim_from_xy
+from mpl_interactions.helpers import sca, update_datalim_from_bbox, update_datalim_from_xy
 
 
 def test_bbox_update():
@@ -44,3 +45,11 @@ def test_xy_update():
     assert ax.dataLim.bounds == (0, 0, 9, 10)
     update_datalim_from_xy(ax, x_scat, y_scat_small, stretch_y=False)
     assert ax.dataLim.bounds == (0.0, 0.0, 9.0, 4.0)
+
+
+def test_sca():
+    fig = Figure()
+    ax = fig.add_subplot(111)
+
+    # this shouldn't fail
+    sca(ax)


### PR DESCRIPTION
important when embedding into a gui framework


inspired by https://discourse.matplotlib.org/t/problem-with-an-unresponsive-slider-controlling-two-plots-on-a-tkinter-figure-canvas/22552