### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9.x"]
+        python-version: ["3.9.x", "3.10.x"]
         matplotlib-version: ["3.4", "3.5"]
     steps:
       - name: Checkout

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 keywords =
     IPython
     Jupyter
@@ -32,7 +33,7 @@ license = BSD
 platforms = Linux, Mac OS X, Windows
 
 [options]
-python_requires = >=3.6, <3.10
+python_requires = >=3.6
 install_requires =
     matplotlib >= 3.4
 packages = find:


### PR DESCRIPTION
I tested this locally with 3.10.4 and everything passed. Not sure if the other workflows should also include 3.10? e.g. `mpl-master-test.yml`.