### PR TITLE
Fix link to examples directory in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ I use the GitHub [issues](https://github.com/ianhi/mpl-interactions/issues) to k
 
 ## Documentation
 
-The fuller narrative documentation can be found on [ReadTheDocs](https://mpl-interactions.readthedocs.io/en/latest/). You may also find it helpful to check out the [examples directory](https://github.com/ianhi/mpl-interactions/tree/master/docs/examples).
+The fuller narrative documentation can be found on [ReadTheDocs](https://mpl-interactions.readthedocs.io/en/latest/). You may also find it helpful to check out the [examples directory](docs/examples).
 
 ## Contributors ✨
 


### PR DESCRIPTION
I noticed that the main branch was renamed from master, but the link to examples weren't updated.
I changed it to a relative path, this way it'll work correctly for every branch.