### PR TITLE
ci: Use matplotlib nightly wheels in HEAD of dependencies testing

### DIFF
--- a/.github/workflows/mpl-master-test.yml
+++ b/.github/workflows/mpl-master-test.yml
@@ -27,10 +27,10 @@ jobs:
 
       - name: Install
         run: |
-          pip install wheel
-          pip install git+https://github.com/matplotlib/matplotlib.git
-          pip install --upgrade --pre ipywidgets
-          pip install ".[jupyter, test]"
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install git+https://github.com/matplotlib/matplotlib.git
+          python -m pip install --upgrade --pre ipywidgets
+          python -m pip install ".[jupyter, test]"
 
       - name: Tests
         run: |

--- a/.github/workflows/mpl-master-test.yml
+++ b/.github/workflows/mpl-master-test.yml
@@ -28,7 +28,11 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install git+https://github.com/matplotlib/matplotlib.git
+          python -m pip install \
+            --upgrade \
+            --pre \
+            --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple \
+            matplotlib
           python -m pip install --upgrade --pre ipywidgets
           python -m pip install ".[jupyter, test]"
 

--- a/.github/workflows/mpl-master-test.yml
+++ b/.github/workflows/mpl-master-test.yml
@@ -36,6 +36,9 @@ jobs:
           python -m pip install --upgrade --pre ipywidgets
           python -m pip install ".[jupyter, test]"
 
+      - name: List installed Python packages
+        run: python -m pip list
+
       - name: Tests
         run: |
           pytest --color=yes


### PR DESCRIPTION
To simplify the `mpl-latest` workflow, instead of trying to install from `matplotlib` `HEAD` on GitHub install from the `scipy-wheels-nightly` org package on Anaconda cloud (https://anaconda.org/scipy-wheels-nightly).

For clarity of what is actually installed and being tested, also list out the packages after install.