### PR TITLE
Update contributing.md for zsh use

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,12 +17,7 @@ pre-commit install
 The `conda env create` command installs all Python packages that are useful when working on the source code of `mpl_interactions` and its documentation. You can also install these packages separately:
 
 ```bash
-pip install -e .[dev]
-```
-for MacOs systems that use zsh instead of bash type:
-```bash
 pip install -e ".[dev]"
-
 ```
 
 The {command}`-e .` flag installs the `mpl_interactions` folder in ["editable" mode](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs) and {command}`[dev]` installs the [optional dependencies](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies) you need for developing `mpl_interacions`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -20,10 +20,10 @@ The `conda env create` command installs all Python packages that are useful when
 pip install -e .[dev]
 ```
 for MacOs systems that use zsh instead of bash type:
-```
+```bash
 pip install -e ".[dev]"
 
-
+```
 
 The {command}`-e .` flag installs the `mpl_interactions` folder in ["editable" mode](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs) and {command}`[dev]` installs the [optional dependencies](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies) you need for developing `mpl_interacions`.
 


### PR DESCRIPTION
On newer MacOs systems zsh is often used instead of bash, which needs slightly different syntax. Edited the contributing file accordingly.