### PR TITLE
Update set_max() function in widgets.py

### DIFF
--- a/mpl_interactions/widgets.py
+++ b/mpl_interactions/widgets.py
@@ -407,7 +407,7 @@ class RangeSlider(SliderBase):
         self.set_val((val, self.val[1]))
 
     def set_max(self, val):
-        """Set the lower value of the slider to *val*.
+        """Set the higher value of the slider to *val*.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixed typo on line 410. Previously said ' """set the lower value of slider to *val*.  ' This is inaccurate as the max  value is the higher value. 